### PR TITLE
Fix: Preserve machine-id to avoid repeated 2FA prompts

### DIFF
--- a/PokeMMO Android.sh
+++ b/PokeMMO Android.sh
@@ -14,6 +14,9 @@ fi
 
 source $controlfolder/control.txt
 
+# If /etc/machine-id doesn't exist and /tmp/dbus/machine-id exists, copy it over
+[ ! -f /etc/machine-id ] && [ -f /tmp/dbus/machine-id ] && cp /tmp/dbus/machine-id /etc/machine-id
+
 # We source custom mod files from the portmaster folder example mod_jelos.txt which containts pipewire fixes
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 

--- a/PokeMMO small.sh
+++ b/PokeMMO small.sh
@@ -14,6 +14,9 @@ fi
 
 source $controlfolder/control.txt
 
+# If /etc/machine-id doesn't exist and /tmp/dbus/machine-id exists, copy it over
+[ ! -f /etc/machine-id ] && [ -f /tmp/dbus/machine-id ] && cp /tmp/dbus/machine-id /etc/machine-id
+
 # We source custom mod files from the portmaster folder example mod_jelos.txt which containts pipewire fixes
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 

--- a/PokeMMO.sh
+++ b/PokeMMO.sh
@@ -14,6 +14,9 @@ fi
 
 source $controlfolder/control.txt
 
+# If /etc/machine-id doesn't exist and /tmp/dbus/machine-id exists, copy it over
+[ ! -f /etc/machine-id ] && [ -f /tmp/dbus/machine-id ] && cp /tmp/dbus/machine-id /etc/machine-id
+
 # We source custom mod files from the portmaster folder example mod_jelos.txt which containts pipewire fixes
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 


### PR DESCRIPTION
### Summary

This PR adds a fallback mechanism to ensure `/etc/machine-id` is restored from `/tmp/dbus/machine-id` if it doesn't exist. This helps maintain a consistent machine identity across reboots or temporary environments, and prevents triggering repeated 2FA prompts from services that rely on a stable machine ID.

### Problem

On systems where `/etc/machine-id` is missing (e.g., live environments, containers, or misconfigured installations), a new machine-id is generated under `/tmp/dbus/machine-id` every boot. This causes services that rely on machine identity to treat the device as "new" each time, resulting in unnecessary 2FA challenges.

### Solution

The added logic checks if `/etc/machine-id` is missing, and if `/tmp/dbus/machine-id` exists, it copies it over. This preserves the identity of the system during boot or container startup.

### Impact

- Reduces friction caused by repeated 2FA prompts
- Ensures more stable identity for D-Bus and related services
- Safe and non-intrusive fallback, only acts if `/etc/machine-id` is missing

### Testing

Tested and verified on **muOS** — resolves the issue of being prompted for 2FA on every login after reboot.